### PR TITLE
add lifecycleowner for mapping data

### DIFF
--- a/app/src/main/java/com/example/deliveryfood/CategoryFragment.kt
+++ b/app/src/main/java/com/example/deliveryfood/CategoryFragment.kt
@@ -6,10 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.deliveryfood.adapter.DishAdapter
 import com.example.deliveryfood.adapter.TagAdapter
+import com.example.deliveryfood.data.CuisineItem
 import com.example.deliveryfood.data.DishItem
 import com.example.deliveryfood.databinding.FragmentCategoryBinding
 import com.example.deliveryfood.view.CategoryViewModel
@@ -20,7 +22,7 @@ class CategoryFragment : Fragment() {
     private lateinit var binding: FragmentCategoryBinding
     private val categoryModel: CategoryViewModel by activityViewModels()
     private val adapterDish = DishAdapter()
-    private lateinit var adapterTag : TagAdapter
+    private lateinit var adapterTag: TagAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -35,8 +37,7 @@ class CategoryFragment : Fragment() {
         categoryModel.apply {
             initRecyclerTag()
             getDishes()
-            val listCurrentDishes = listDishes.value as ArrayList<DishItem>
-            initRecyclerDish(listCurrentDishes)
+            observeState()
         }
 
     }
@@ -50,7 +51,6 @@ class CategoryFragment : Fragment() {
         }
     }
 
-
     private fun initRecyclerTag() {
         binding.apply {
             adapterTag = TagAdapter(categoryModel)
@@ -60,4 +60,11 @@ class CategoryFragment : Fragment() {
         }
     }
 
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            categoryModel.listDishes.collect {
+                initRecyclerDish(it as ArrayList<DishItem>)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/deliveryfood/MainFragment.kt
+++ b/app/src/main/java/com/example/deliveryfood/MainFragment.kt
@@ -1,14 +1,14 @@
 package com.example.deliveryfood
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.deliveryfood.adapter.CuisineAdapter
-import com.example.deliveryfood.adapter.TagAdapter
 import com.example.deliveryfood.data.CuisineItem
 import com.example.deliveryfood.databinding.FragmentMainBinding
 import com.example.deliveryfood.view.CuisineViewModel
@@ -19,7 +19,6 @@ class MainFragment : Fragment() {
     private lateinit var binding: FragmentMainBinding
     private val cuisineModel: CuisineViewModel by activityViewModels()
     private val adapterCuisine = CuisineAdapter(this)
-    private lateinit var listCurrentCuisines: ArrayList<CuisineItem>
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -31,8 +30,7 @@ class MainFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         cuisineModel.getCuisines()
-        listCurrentCuisines = cuisineModel.listCuisines.value as ArrayList<CuisineItem>
-        initRecyclerCuisine(listCurrentCuisines)
+        observeState()
     }
 
     private fun initRecyclerCuisine(listCuisines: ArrayList<CuisineItem>) {
@@ -44,4 +42,11 @@ class MainFragment : Fragment() {
         }
     }
 
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            cuisineModel.listCuisines.collect {
+                initRecyclerCuisine(it as ArrayList<CuisineItem>)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Был баг с тем, что при первом отображении экрана на нем не показывались данные с stateflow переменной. Это было потому, что в переменной ничего не было,  так как данные с api приходили позже.
Добавил viewLifecycleOwner  для отслеживания жизненного цикла фрагмента. Далее запускаем карутину с помощью lifecycleScope.launchWhenStarted , где она запуститься в методе  onStart() жизненого цикла фрагмента. Потом с помощью collect получаем данные которые пришли в нужную переменную stateflow.